### PR TITLE
7.5 Добавить ещё одно WEB API (кроме Canvas, Fetch)

### DIFF
--- a/packages/client/src/app/providers/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/client/src/app/providers/ErrorBoundary/ErrorBoundary.tsx
@@ -1,7 +1,6 @@
 import { Alert, Button, Card, Collapse, Typography } from 'antd'
 import { Component, ErrorInfo, ReactNode } from 'react'
 
-import { redirect } from 'react-router'
 import style from './ErrorBoundary.module.scss'
 
 interface ErrorBoundaryProps {
@@ -9,11 +8,16 @@ interface ErrorBoundaryProps {
   fallBackComponent?: ReactNode
 }
 
-interface ErrorBoundaryState {
-  hasError: boolean
-  errorInfo?: string
-  errorMessage?: string
-}
+type ErrorBoundaryState =
+  | {
+      hasError: true
+      errorInfo?: string | null
+      errorMessage?: string
+    }
+  | {
+      hasError: false
+    }
+
 const { Text } = Typography
 
 const initialErrorState: ErrorBoundaryState = { hasError: false }
@@ -42,8 +46,8 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
     this.setState(initialErrorState)
   }
   render(): ReactNode {
-    const { errorMessage, errorInfo } = this.state
     if (this.state.hasError) {
+      const { errorMessage, errorInfo } = this.state
       return this.props.fallBackComponent ? (
         this.props.fallBackComponent
       ) : (

--- a/packages/client/src/shared/lib/utils/files.ts
+++ b/packages/client/src/shared/lib/utils/files.ts
@@ -1,0 +1,40 @@
+import { FileExtension } from '@/shared/types/fileSystem'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function jsonToCsvString(
+  jsonData: Record<string, any>[],
+  rowHeaders?: string[],
+  separator = ','
+) {
+  let csv = ''
+  const dataFields = Object.keys(jsonData[0])
+  const headers = rowHeaders ?? Object.keys(jsonData[0])
+  csv += headers.join(separator) + '\n'
+  jsonData.forEach(obj => {
+    const values = dataFields.map(header => obj[header])
+    csv += values.join(separator) + '\n'
+  })
+  return csv
+}
+
+export async function saveDataToFile(
+  data: string,
+  suggestedFileName = `tower-defense_${new Date().toISOString().split('T')[0]}`
+) {
+  const taBlob = new Blob([data], { type: 'text/plain' })
+  const pickerOptions = {
+    suggestedName: `${suggestedFileName.toLowerCase()}.txt`,
+    types: [
+      {
+        description: 'Simple Text File',
+        accept: {
+          'text/plain': ['.txt' as FileExtension],
+        },
+      },
+    ],
+  }
+  const fileHandle = await window.showSaveFilePicker(pickerOptions)
+  const writableFileStream = await fileHandle.createWritable()
+  await writableFileStream.write(taBlob)
+  await writableFileStream.close()
+}

--- a/packages/client/src/shared/types/fileSystem.ts
+++ b/packages/client/src/shared/types/fileSystem.ts
@@ -1,0 +1,34 @@
+export type WellKnownDirectory =
+  | 'desktop'
+  | 'documents'
+  | 'downloads'
+  | 'music'
+  | 'pictures'
+  | 'videos'
+export type FileExtension = `.${string}`
+export type MIMEType = `${string}/${string}`
+export interface FilePickerAcceptType {
+  /**
+   * @default ""
+   */
+  description?: string | undefined
+  accept?: Record<MIMEType, FileExtension | FileExtension[]> | undefined
+}
+
+export interface FilePickerOptions {
+  types?: FilePickerAcceptType[] | undefined
+  /**
+   * @default false
+   */
+  excludeAcceptAllOption?: boolean | undefined
+  startIn?: WellKnownDirectory | FileSystemHandle | undefined
+  id?: string | undefined
+}
+
+declare global {
+  interface Window {
+    showSaveFilePicker: (
+      options?: FilePickerOptions
+    ) => Promise<FileSystemFileHandle>
+  }
+}


### PR DESCRIPTION
Добавлено ещё одно WEB API (кроме Canvas, Fetch) - работа с Geolocation API и файлами (FileSystem API) для сохранения результатов (Лидерборд) в локальном файле пользователя.

**Скриншоты/видяшка**
Кнопка "Сохранить таблицу" позволяет сохранить таблицу (в формате txt) в файле локально (на устройстве пользователя):
![image](https://github.com/user-attachments/assets/be8164bf-5bbd-4e8b-a340-5b45fe5f2e5e)

В файле таблице сохраняются как данные из таблицы, так и местоположение пользователя в момент сохранения результатов:
![image](https://github.com/user-attachments/assets/e35b0b7a-cd3f-4f38-8b92-4f6d04a2ed0b)

**TBD**
В дальнейшем может быть полезно сделать кастомизацию хранения файлов - возможности (диалог) выбора типа/формата файла для сохранения данных локально, состава сохраняемых данных (включения заголовков, отдельных строк и т.п.).
